### PR TITLE
changed FUTURES_COIN_URL

### DIFF
--- a/unicorn_binance_rest_api/unicorn_binance_rest_api_manager.py
+++ b/unicorn_binance_rest_api/unicorn_binance_rest_api_manager.py
@@ -54,7 +54,7 @@ class BinanceRestApiManager(object):
     WEBSITE_URL = 'https://www.binance.{}'
     FUTURES_URL = 'https://fapi.binance.{}/fapi'
     FUTURES_DATA_URL = 'https://fapi.binance.{}/futures/data'
-    FUTURES_COIN_URL = "https://dapi.binance.{}/dapi"
+    FUTURES_COIN_URL = "https://fapi.binance.{}/fapi"
     FUTURES_COIN_DATA_URL = "https://dapi.binance.{}/futures/data"
     PUBLIC_API_VERSION = 'v1'
     PRIVATE_API_VERSION = 'v3'


### PR DESCRIPTION

# PR Details

changed FUTURES_COIN_URL

## Description

value was "https://dapi.binance.{}/dapi" but I think it should be "https://fapi.binance.{}/fapi"
I've tried to use the futures_coin_klines method but only got invalid symbol errors. Checking the logfile revealed that the URI used seems to be wrong as per https://binance-docs.github.io/apidocs/futures/en/#kline-candlestick-data doc. Changing the URL to the proposed value results in the method working fine.

## Related Issue
 
#4 

## Motivation and Context

URI for futures data retrieval seems to be wrong and results in e.g. futures_coin_klines() to fail with 'invalid symbol' errors.

## How Has This Been Tested

method futures_coin_klines() did not work before, did work afterwards.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the 
**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/blob/master/CONTRIBUTING.md)** 
document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
