### PR TITLE
chore(ktw): bump context-schema to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,6 @@ ubra_futures = BinanceRestApiManager(exchange="binance.com-futures")
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.1
+- context-schema: 0.8.0
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -24,6 +24,7 @@ For usage, installation, operation, or troubleshooting, see `docs/`.
 
 Each entry separates:
 
+- **Type** — what kind of thing it is: decision, workaround, incident, or constraint (or undefined, with a reason, if none fit)
 - **Status** — whether a decision is active, superseded, open, or needs review
 - **Evidence** — whether its rationale is confirmed, inferred, or unknown
 

--- a/context/history.md
+++ b/context/history.md
@@ -2,6 +2,7 @@
 
 ## LUCIT-Systems-and-Development origin
 
+**Type:** decision
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
 **Evidence:** confirmed
 **Source:** git history
@@ -14,6 +15,7 @@ The repo moved into the `LUCIT-Systems-and-Development` GitHub org (commit `e811
 
 ## The 5-file dependency sync rule caught its own violation
 
+**Type:** incident
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `9599c72`

--- a/context/portfolio-margin.md
+++ b/context/portfolio-margin.md
@@ -2,6 +2,7 @@
 
 ## Deliberately minimal: just enough for UBWA's listenKey needs
 
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** CHANGELOG, 2.11.0.dev entry; issue [#452](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api/issues/452)

--- a/context/testing.md
+++ b/context/testing.md
@@ -2,6 +2,7 @@
 
 ## CI initializes against `binance.us`, not `binance.com`
 
+**Type:** workaround
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `050284a`
@@ -14,6 +15,7 @@
 
 ## `colorama.init(wrap=False)`
 
+**Type:** workaround
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `f8bb80c`


### PR DESCRIPTION
Migrates the project's keep-the-why context-schema from its previous value to 0.8.0.

- Bumps `context-schema` in AGENTS.md.
- Adds the Type field line to `context/README.md`'s "Reading the entries" section (0.7.0/0.8.0 migration step).

Individual context/ entries are not backfilled in bulk — per the skill's migration guidance, an entry picks up a Type value the next time it's touched anyway, not as a dedicated pass.