### PR TITLE
chore: bump keep-the-why context-schema to 0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,6 @@ ubra_futures = BinanceRestApiManager(exchange="binance.com-futures")
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.8.0
+- context-schema: 0.9.0
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->


### PR DESCRIPTION
## Summary
- keep-the-why `context-schema` von 0.8.0 auf 0.9.0 (Type-Feld akzeptiert jetzt mehrere Werte, siehe keep-the-why migrations.md)
- Kontrolle aller `context/`-Einträge: Type/Status/Evidence vollständig und valide, `context/README.md`-Type-Zeile bereits generisch formuliert — keine weiteren Änderungen nötig
- Kein Bulk-Backfill auf Multi-Type-Zeilen (laut Skill-Migrationsregel nur beim nächsten inhaltlichen Touch eines Eintrags)

Co-Authored-By: oliver-zehentleitner-aigent <noreply@anthropic.com>