### PR TITLE
Keep the Why: migrate to 0.11.0 and add ktw-lint CI

### DIFF
--- a/.github/workflows/ktw-lint.yml
+++ b/.github/workflows/ktw-lint.yml
@@ -1,0 +1,17 @@
+name: ktw-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  ktw-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oliver-zehentleitner/keep-the-why@lint-latest   # or @lint-v<version> to pin the action
+        with:
+          path: "."
+          strict: "false"    # "true" turns warnings (e.g. missing Type on old entries) into failures
+          # version: "0.11.0.0"   # optional: pin the linter itself; @lint-v<version> above pins only the wrapper

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -1,0 +1,12 @@
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: oliver-zehentleitner---unicorn-binance-rest-api
+- context: `context/`
+- init: complete
+- context-schema: 0.11.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why:config -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,9 +187,5 @@ ubra_futures = BinanceRestApiManager(exchange="binance.com-futures")
 - `unicorn-binance-trailing-stop-loss` — for order placement and account queries
 - `unicorn-binance-local-depth-cache` — for initial snapshot fetching
 
-<!-- keep-the-why:config -->
-- context: `context/`
-- init: complete
-- context-schema: 0.9.0
-- capture-confirmation: confirm-when-unsure
-<!-- /keep-the-why:config -->
+Keep the Why's config for this project migrated to .keep-the-why on
+2026-09-04 — requires skill version 0.10.0 or later to read it.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-rest-api/graph/badge.svg?token=P7XILPPSLU)](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-rest-api)
 [![CodeQL](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/codeql-analysis.yml)
 [![Unittests](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/unit-tests.yml)
+[![ktw-lint](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/ktw-lint.yml)
 [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api/actions/workflows/build_wheels.yml)
 [![Conda-Forge Build](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/unicorn-binance-rest-api-feedstock?branchName=main)](https://github.com/conda-forge/unicorn-binance-rest-api-feedstock)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-rest-api/)

--- a/context/AGENTS.md
+++ b/context/AGENTS.md
@@ -1,0 +1,1 @@
+Before creating or editing anything in this directory, invoke the keep-the-why skill. Don't write to the schema by hand.

--- a/context/CLAUDE.md
+++ b/context/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/context/history.md
+++ b/context/history.md
@@ -2,8 +2,10 @@
 
 ## LUCIT-Systems-and-Development origin
 
+> Superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed.
+
 **Type:** decision
-**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Status:** superseded
 **Evidence:** confirmed
 **Source:** git history
 

--- a/context/index.md
+++ b/context/index.md
@@ -1,5 +1,5 @@
 # Context index
 
+- [history.md](history.md) — the LUCIT-Systems-and-Development origin, and a dependency-file drift it exposed
 - [portfolio-margin.md](portfolio-margin.md) — why Portfolio Margin support here is deliberately minimal (listenKey only)
 - [testing.md](testing.md) — why CI tests init against `binance.us`, and the colorama recursion fix
-- [history.md](history.md) — the LUCIT-Systems-and-Development origin, and a dependency-file drift it exposed


### PR DESCRIPTION
Suite-wide Keep the Why migration to schema **0.11.0**, plus the structural linter in CI.

**Migrations applied (per `references/migrations.md`)**

- **0.10.0 – dedicated config file:** the `<!-- keep-the-why:config -->` block moves from `AGENTS.md` into `.keep-the-why`. Every existing field is carried over verbatim; new `id` field (`oliver-zehentleitner---<repo>`, derived from the canonical upstream remote, not the fork), and `source-reference` backfilled to its documented default `never`. `AGENTS.md` keeps only the one-line migration note the migration guide asks for.
- **0.10.0 – guard files:** `context/AGENTS.md` + `context/CLAUDE.md`. Where `.gitignore` had an unanchored `CLAUDE.md` pattern it is now `/CLAUDE.md`, so the root file stays local and the nested guard file is tracked.
- **0.10.0 – `context/index.md` sorted alphabetically** (where it wasn't already).
- **0.11.0 – rule renumbering:** checked, no living document in this repo cites a remapped rule number.
- **0.11.0 – CI linting:** `.github/workflows/ktw-lint.yml`, the wizard snippet with `branches: [ master ]` to match the other workflows here. Non-strict by default; `@lint-latest` follows linter publishes.

**Linter-driven cleanups in `context/`**

`ktw-lint --strict` flagged header values outside the documented set. Normalized without dropping information: a trailing reason on `**Status:** superseded — …` moves into a `> Superseded — …` note directly under the entry heading (the same pattern keep-the-why's own `context/` uses); redundant suffixes on `open`/`active` entries (already stated in the entry body, Type reason or Source line) are dropped. See the diff for the exact lines.

**Verification**

- `ktw-lint . --strict` (0.11.0.0): 0 errors, 0 warnings, context-schema 0.11.0.
- Not done here: nothing personal (`AGENTS.local.md` is untracked, `~/.keep-the-why/<id>.md` is per developer), no `personal-defaults` block (optional, project's call).

**Follow-up commit:** `ktw-lint` workflow badge added to `README.md`, directly after the Unit Tests badge.
